### PR TITLE
addressed more feedback

### DIFF
--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useCallback, useEffect, useState} from 'react';
 import {AppPluginMeta, PluginConfigPageProps} from '@grafana/data';
 import {getBackendSrv} from '@grafana/runtime';
-import {Button} from '@grafana/ui';
+import {Button, InlineField, Input} from '@grafana/ui';
 import {ApplicationName, ApplicationRoot} from '../../constants';
 import {GlobalSettings} from '../../types';
 
@@ -116,19 +116,17 @@ export const Config: FC<Props> = (props) => {
                     <p>
                         Get out-of-the-box Embrace dashboards in minutes with our simple configuration. Enter your Embrace API Token below and click to Enable the Application.
                     </p>
-                    <form>
-                        <label>
-                            Embrace API Token: &nbsp;
-                            <input
-                                type="text"
-                                value={apiToken}
-                                onChange={(e) => setApiToken(e.target.value)}
-                                size={50}
-                            />
-                        </label>
-                    </form>
-                    {showErrorMessage &&
-                        <p style={{color: 'red'}}> Your API token was invalid. Please try again. </p>}
+                    <InlineField
+                        label="Embrace API Token"
+                        error="Your API token was invalid. Please try again"
+                        invalid={showErrorMessage}
+                    >
+                        <Input placeholder="Token"
+                               onChange={(e) => setApiToken(e.currentTarget.value)}
+                               value={apiToken}
+                               width={50}
+                               />
+                    </InlineField>
                 </React.Fragment>
             )}
             <div className="gf-form gf-form-button-row">

--- a/src/components/AppConfig/__snapshots__/AppConfig.test.tsx.snap
+++ b/src/components/AppConfig/__snapshots__/AppConfig.test.tsx.snap
@@ -11,16 +11,33 @@ exports[`Components/AppConfig renders without an error" 1`] = `
   <p>
     Get out-of-the-box Embrace dashboards in minutes with our simple configuration. Enter your Embrace API Token below and click to Enable the Application.
   </p>
-  <form>
-    <label>
-      Embrace API Token:  
-      <input
-        size="50"
-        type="text"
-        value=""
-      />
+  <div
+    class="css-1f5gueu"
+  >
+    <label
+      class="css-1pews2r"
+    >
+      Embrace API Token
     </label>
-  </form>
+    <div
+      class="css-1rfunm5"
+    >
+      <div
+        class="css-p7rfez-input-wrapper"
+        data-testid="input-wrapper"
+      >
+        <div
+          class="css-1w5c5dq-input-inputWrapper"
+        >
+          <input
+            class="css-1wdli31-input-input"
+            placeholder="Token"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
   <div
     class="gf-form gf-form-button-row"
   >


### PR DESCRIPTION
> Please replace the `<form />` , `<label />` and `<input />` form elements in the AppConfig.tsx with the Grafana/UI  [InlineField](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-inlinefield--basic) react component to keep the plugin config UI consistent with both the Grafana applications and other plugins. You should also be able to make use of the error and invalid props on the <InlineField /> component to replace the red `<p />` error message that currently appears. ([See Grafana storybook example](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-inlinefield--error&args=error:The+error+message).)

This is the feedback from Grafana.