### PR TITLE
EMB-11304 - update version on build

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           node-version: '16'
           cache: 'yarn'
+      - name: Update version on package.json
+        run: |
+          sed -i "s/\"version\": \"1.0.0\"/\"version\": \"${{ github.event.release.tag_name }}\"/g" package.json
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Build dependencies


### PR DESCRIPTION
## Summary
- webpack uses the version from package.json when it creates the plugin.json file during build. This change will update the version tag created and update package.json before that step.