### PR TITLE
EMB-15018 - Use "docker compose" syntax, since docker-compose is deprecated.

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Build dependencies
         run: yarn build
       - name: Start Grafana container
-        run: docker-compose --file compose.yaml up --detach
+        run: docker compose --file compose.yaml up --detach
       - name: Run e2e tests
         run: yarn e2e
       - name: Stop Grafana container
-        run: docker-compose --file compose.yaml down
+        run: docker compose --file compose.yaml down
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/